### PR TITLE
change handling url settings so that our llm can access cloudinary

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -15,7 +15,7 @@ class SearchesController < ApplicationController
       @chat = RubyLLM.chat(model: "gpt-4o")
 
       @response = if @search.uploaded_image.attached?
-        @chat.ask("Analyze this clothing item.", with: { image: url_for(@search.uploaded_image) })
+        @chat.ask("Analyze this clothing item.", with: { image: @search.uploaded_image.url })
       else
         @chat.ask("Analyze the clothing item at: #{@search.uploaded_link}")
       end


### PR DESCRIPTION
**The flow should be:**
1. User uploads an image file (e.g., shirt.jpg)
2. Active Storage + Cloudinary stores it
3. Getting the URL to send to the LLM (hence, @search.uploaded_image.url -> should returns the Cloudinary CDN URL where the image is publicly accessible).
4. The LLM receives the URL and fetches the image.


