### PR TITLE
Add About us and Contact pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,10 @@
 class PagesController < ApplicationController
   def home
   end
+
+  def about
+  end
+
+  def contact
+  end
 end

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,43 @@
+<div class="container py-5">
+  <h1 class="mb-4">About EcoMatch</h1>
+
+  <div class="row g-4">
+    <div class="col-md-6">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">What we do</h5>
+          <p class="card-text">EcoMatch helps you find more sustainable alternatives to fast-fashion items. Upload a photo or paste a product link, and EcoMatch suggests similar products from brands that prioritize better materials, fairer production, and transparency.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">Why we built it</h5>
+          <p class="card-text">We know that shopping more sustainably is hard. Information is scattered, claims are unclear, and finding comparable alternatives takes time. EcoMatch was built to make sustainable choices easier and more accessible — without asking users to become experts.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">How it works</h5>
+          <ul class="card-text mb-0">
+            <li>You upload a product image or link</li>
+            <li>EcoMatch identifies key features (category, style, materials)</li>
+            <li>We suggest comparable products from more sustainable brands</li>
+            <li>You can save your favorites to a wishlist</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">What sustainable means to us</h5>
+          <p class="card-text">Sustainability is complex. EcoMatch does not claim to be perfect or exhaustive. Our recommendations are based on available information such as materials, certifications, brand transparency, and publicly shared practices. Our sustainability ranking is based on <%= link_to "Good On You", "https://goodonyou.eco/", target: "_blank", rel: "noopener" %>.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,0 +1,5 @@
+<div class="container py-5">
+  <h1 class="mb-4">Contact</h1>
+  <p class="lead">Have feedback, questions, or suggestions?</p>
+  <p>We'd love to hear from you. Send us an email to: <%= mail_to "hello@ecomatch.info", "hello@ecomatch.info" %>.</p>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,6 +15,12 @@
             <%= link_to "Home", root_path, class: "nav-link" %>
           </li>
           <li class="nav-item">
+            <%= link_to "About us", about_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Contact", contact_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
             <%= link_to "My Wishlist", wishlist_user_path(current_user), class: "nav-link" %>
           </li>
           <li class="nav-item dropdown">
@@ -27,9 +33,15 @@
             </div>
           </li>
         <% else %>
-          <!--li class="nav-item"-->
+          <li class="nav-item">
+            <%= link_to "About us", about_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Contact", contact_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
             <%= link_to "Login", new_user_session_path, class: "nav-link" %>
-          <!--/li-->
+          </li>
         <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+  get "about", to: "pages#about", as: :about
+  get "contact", to: "pages#contact", as: :contact
 
   # Defines the root path route ("/")
   # root "posts#index"


### PR DESCRIPTION
## Implemented
- Routes: get about, get contact
- PagesController: about, contact actions
- About: 4 Bootstrap cards (what we do, why, how it works, sustainability)
- Contact: container with mailto link to hello@ecomatch.info
- Navbar: About us and Contact links for signed-in and guest users