### PR TITLE
fixed hidden search to autopopulate with preselected item (t-shirt, j…

### DIFF
--- a/app/assets/stylesheets/pages/_matches.scss
+++ b/app/assets/stylesheets/pages/_matches.scss
@@ -23,9 +23,9 @@ a{
   text-decoration: none;
 }
 
-.results-section__filters form .first-input-field:first-of-type {
-  display: none;
-}
+// .results-section__filters form .first-input-field:first-of-type {
+//   display: none;
+// }
 .card-product-lg {
   overflow: hidden;
   margin: 32px 0;

--- a/app/jobs/search_analysis_job.rb
+++ b/app/jobs/search_analysis_job.rb
@@ -37,25 +37,7 @@ class SearchAnalysisJob < ApplicationJob
 
   private
 
-  # Analyze an uploaded image using GPT-4o vision
-  def analyze_image(search)
-    Rails.logger.info "[SearchAnalysisJob] Analyzing image for search ##{search.id}"
-
-    chat = RubyLLM.chat(model: "gpt-4o").with_instructions(search.system_prompt)
-    response = chat.ask(
-      "Analyze this clothing item and return the JSON.",
-      with: { image: search.uploaded_image.url }
-    )
-
-    json_content = response.content.gsub(/```json\s*/, '').gsub(/```\s*/, '').strip
-    parsed = JSON.parse(json_content) rescue nil
-
-    if parsed
-      update_search_with_parsed_data(search, parsed, image_upload: true)
-    end
-  end
-
-  # Analyze a product link using ScrapingBee + GPT-4o
+  # Analyze a product link using ScrapingBee + GPT
   def analyze_link(search)
     Rails.logger.info "[SearchAnalysisJob] Analyzing link for search ##{search.id}: #{search.uploaded_link}"
 
@@ -168,6 +150,8 @@ class SearchAnalysisJob < ApplicationJob
 
   # Build the analysis prompt for link-based searches
   def build_link_analysis_prompt(scraped_data)
+    valid_items = ComparisonProduct.valid_clothing_items.join(", ")
+
     <<~PROMPT
       Analyze this product information and extract clothing details.
 
@@ -177,11 +161,10 @@ class SearchAnalysisJob < ApplicationJob
 
       Extract these fields:
 
-      clothing_item: ONLY the garment type, NO colors or style modifiers.
-        - "white t-shirt" → "t-shirt"
-        - "blue skinny jeans" → "jeans"
-        - "red maxi dress" → "dress"
-        - "black leather jacket" → "jacket"
+      clothing_item: MUST be EXACTLY ONE of these values: #{valid_items}
+        - Choose the closest match from the list above
+        - Use ONLY the exact values listed (all lowercase, hyphenated)
+        - Examples: "white t-shirt" → "t-shirt", "blue jeans" → "jeans", "winter coat" → "coat"
 
       clothing_colour: The color. Use ONLY: black, white, grey, blue, red, green, yellow, orange, pink, purple, brown, beige, multicolor
 
@@ -192,7 +175,28 @@ class SearchAnalysisJob < ApplicationJob
       clothing_price: Price as number only, or null
 
       Return ONLY valid JSON, no markdown:
-      {"clothing_item": "garment type only", "clothing_colour": "base color", "clothing_material": "fabric or null", "clothing_brand": "brand", "clothing_price": null}
+      {"clothing_item": "exact value from list", "clothing_colour": "base color", "clothing_material": "fabric or null", "clothing_brand": "brand", "clothing_price": null}
     PROMPT
+  end
+
+  # Analyze an uploaded image using GPT-4o vision
+  def analyze_image(search)
+    Rails.logger.info "[SearchAnalysisJob] Analyzing image for search ##{search.id}"
+
+    valid_items = ComparisonProduct.valid_clothing_items.join(", ")
+    system_instructions = "#{search.system_prompt}\n\nIMPORTANT: For clothing_item, ONLY use one of: #{valid_items}"
+
+    chat = RubyLLM.chat(model: "gpt-4o").with_instructions(system_instructions)
+    response = chat.ask(
+      "Analyze this clothing item and return the JSON.",
+      with: { image: search.uploaded_image.url }
+    )
+
+    json_content = response.content.gsub(/```json\s*/, '').gsub(/```\s*/, '').strip
+    parsed = JSON.parse(json_content) rescue nil
+
+    if parsed
+      update_search_with_parsed_data(search, parsed, image_upload: true)
+    end
   end
 end

--- a/app/models/comparison_product.rb
+++ b/app/models/comparison_product.rb
@@ -30,4 +30,22 @@ class ComparisonProduct < ApplicationRecord
   scope :ordered_by_params, lambda { |_rating, _desc|
     joins(:brand).order("brands.overall_rating DESC")
   }
+
+  def self.unique_clothing_items
+    distinct.pluck(:clothing_item).compact.reject(&:blank?).sort
+  end
+
+  def self.valid_clothing_items
+    [
+      "t-shirt",
+      "hoodie",
+      "jacket",
+      "jeans",
+      "leggings",
+      "pants",
+      "shorts",
+      "sweater",
+      "shirt"
+  ].sort
+  end
 end

--- a/app/views/shared/_product_filters.html.erb
+++ b/app/views/shared/_product_filters.html.erb
@@ -8,7 +8,14 @@
   <div class="row g-3">
     <div class="col-md-3 first-input-field">
       <%= label_tag :clothing_item, "CLOTIHING ITEM", class: "form-label" %>
-      <%= text_field_tag :clothing_item,
+      <%= select_tag :clothing_item,
+          options_for_select(
+            [["Any", ""]] + ComparisonProduct.valid_clothing_items.map { |item| [item.titleize, item] },
+            params[:clear].present? ? nil : (params[:clothing_item] || local_assigns[:search]&.clothing_item)
+          ),
+          class: "form-select",
+          data: { action: "change->filter-form#submit" } %>
+      <%# <%= text_field_tag :clothing_item,
           params[:clear].present? ? nil : (params[:clothing_item] || local_assigns[:search]&.clothing_item&.capitalize),
           class: "form-control",
           placeholder: "e.g. T-shirt, Jacket",


### PR DESCRIPTION
…acket etc.) and supporting model logic
This pull request introduces several improvements to the way clothing items are handled and analyzed throughout the application. The changes standardize the set of valid clothing items, ensure consistency between image and link analysis, and update the product filter UI to use a dropdown for clothing item selection.

**Standardization and Consistency Improvements:**

* Added a `valid_clothing_items` method to the `ComparisonProduct` model to define a standardized list of allowed clothing items. This list is now used throughout the application for both filtering and AI analysis.
* Updated both the image and link analysis prompts in `SearchAnalysisJob` to require that the `clothing_item` field is exactly one of the standardized values, ensuring consistent data extraction from both images and product links. [[1]](diffhunk://#diff-7af48ce7bf6aef2540516669643c2c3e566b12b3a1eb071b008333a93ebf2abeL180-R167) [[2]](diffhunk://#diff-7af48ce7bf6aef2540516669643c2c3e566b12b3a1eb071b008333a93ebf2abeL195-R201)

**User Interface Updates:**

* Changed the clothing item filter in the product filters partial from a free-text field to a dropdown select, populated with the standardized clothing items for more reliable filtering.
* Commented out the CSS rule that previously hid the first input field in the filters section, likely to ensure the new dropdown is visible.

**Code Organization:**

* Added a `unique_clothing_items` method to the `ComparisonProduct` model for retrieving all unique clothing items present in the database, although the main filtering now uses the standardized list.